### PR TITLE
Stable version of Spiral Framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
-        "spiral/framework": "3.0.x-dev",
         "spiral/nyholm-bridge": "^1.2",
         "spiral/attributes": "^2.8 || ^3.0",
         "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.5",
+        "spiral/framework": "^3.0",
         "spiral/nyholm-bridge": "^1.2",
         "spiral/attributes": "^2.8 || ^3.0",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
We can't remove the Spiral Framework from dependencies because bootloaders are used:
https://github.com/spiral-packages/laravel-validator/blob/master/src/Bootloader/ValidatorBootloader.php#L11
https://github.com/spiral-packages/laravel-validator/blob/master/src/Bootloader/ValidatorBootloader.php#L12